### PR TITLE
Global hotkey (Ctrl+Shift+M) to show/hide MemoDock

### DIFF
--- a/src/MemoDock.App/App.xaml.cs
+++ b/src/MemoDock.App/App.xaml.cs
@@ -14,7 +14,7 @@ namespace MemoDock.App
         {
             try
             {
-                DatabaseService.Instance.Initialize();  
+                DatabaseService.Instance.Initialize();
             }
             catch (Exception ex)
             {
@@ -35,11 +35,14 @@ namespace MemoDock.App
             MainWindow = win;
             win.Show();
 
+            try { GlobalHotkeyService.Instance.RegisterDefault(); } catch (Exception ex) { Logger.Log("Global hotkey init failed", ex); }
+
             base.OnStartup(e);
         }
 
         protected override void OnExit(ExitEventArgs e)
         {
+            try { GlobalHotkeyService.Instance.Dispose(); } catch { }
             try { TrayService.Instance.Dispose(); } catch { }
             base.OnExit(e);
         }

--- a/src/MemoDock.App/Services/GlobalHotkeyService.cs
+++ b/src/MemoDock.App/Services/GlobalHotkeyService.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using MemoDock.Services;
+using Application = System.Windows.Application; // Logger
+
+namespace MemoDock.App.Services
+{
+    /// <summary>
+    /// Globalny skrót Ctrl+Shift+M do Show/Hide okna głównego.
+    /// Stały (bez konfiguracji).
+    /// </summary>
+    public sealed class GlobalHotkeyService : IDisposable
+    {
+        public static GlobalHotkeyService Instance { get; } = new();
+
+        private GlobalHotkeyService() { }
+
+        private const int WM_HOTKEY = 0x0312;
+        private const uint MOD_ALT = 0x0001;
+        private const uint MOD_CONTROL = 0x0002;
+        private const uint MOD_SHIFT = 0x0004;
+        private const uint MOD_WIN = 0x0008;
+        private const uint MOD_NOREPEAT = 0x4000;
+
+        private const int HOTKEY_ID = 1;
+
+        private HwndSource? _source;
+        private IntPtr _hWnd = IntPtr.Zero;
+        private bool _registered;
+
+        public void RegisterDefault()
+        {
+            Unregister();
+
+            var p = new HwndSourceParameters("MemoDock_GlobalHotkeyWnd")
+            {
+                Width = 0,
+                Height = 0,
+                PositionX = 0,
+                PositionY = 0,
+                ParentWindow = new IntPtr(-3) 
+            };
+            _source = new HwndSource(p);
+            _source.AddHook(WndProc);
+            _hWnd = _source.Handle;
+
+            uint mods = MOD_CONTROL | MOD_SHIFT | MOD_NOREPEAT;
+            uint vkM = (uint)'M';
+
+            if (!RegisterHotKey(_hWnd, HOTKEY_ID, mods, vkM))
+            {
+                var err = Marshal.GetLastWin32Error();
+                Logger.Log($"GlobalHotkey: RegisterHotKey failed (win32={err}) for Ctrl+Shift+M");
+                try { _source.RemoveHook(WndProc); } catch { }
+                try { _source.Dispose(); } catch { }
+                _source = null;
+                _hWnd = IntPtr.Zero;
+                return;
+            }
+
+            _registered = true;
+        }
+
+        public void Unregister()
+        {
+            try
+            {
+                if (_registered && _hWnd != IntPtr.Zero)
+                    UnregisterHotKey(_hWnd, HOTKEY_ID);
+            }
+            catch { /* ignore */ }
+            finally
+            {
+                _registered = false;
+                if (_source != null)
+                {
+                    try { _source.RemoveHook(WndProc); } catch { }
+                    try { _source.Dispose(); } catch { }
+                    _source = null;
+                }
+                _hWnd = IntPtr.Zero;
+            }
+        }
+
+        private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam, ref bool handled)
+        {
+            if (msg == WM_HOTKEY && wparam.ToInt32() == HOTKEY_ID)
+            {
+                handled = true;
+                try { Application.Current?.Dispatcher?.Invoke(ToggleShowHide); }
+                catch (Exception ex) { Logger.Log("GlobalHotkey toggle failed", ex); }
+            }
+            return IntPtr.Zero;
+        }
+
+        private static void ToggleShowHide()
+        {
+            var app = Application.Current;
+            if (app == null) return;
+
+            if (app.MainWindow is not Window w)
+            {
+                w = new MemoDock.App.Views.MainWindow();
+                app.MainWindow = w;
+            }
+
+            if (!w.IsVisible || w.WindowState == WindowState.Minimized)
+            {
+                if (!w.IsVisible) w.Show();
+                if (w.WindowState == WindowState.Minimized) w.WindowState = WindowState.Normal;
+                w.Activate();
+                w.Topmost = true;
+                w.Topmost = false;
+            }
+            else
+            {
+                w.Hide();
+            }
+        }
+
+        public void Dispose() => Unregister();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+    }
+}

--- a/src/MemoDock.App/ViewModels/SettingsViewModel.cs
+++ b/src/MemoDock.App/ViewModels/SettingsViewModel.cs
@@ -24,7 +24,7 @@ namespace MemoDock.ViewModels
         private void Save()
         {
             SettingsService.Instance.Save();
-            System.Windows.MessageBox.Show("Zapisano ustawienia.", "OK",
+            System.Windows.MessageBox.Show("Settings saved.", "OK",
                 System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Information);
         }
 
@@ -33,21 +33,21 @@ namespace MemoDock.ViewModels
         {
             if (string.IsNullOrWhiteSpace(S.BackupFolder))
             {
-                System.Windows.MessageBox.Show("Wybierz folder kopii.", "Uwaga",
+                System.Windows.MessageBox.Show("Choose a backup folder first.", "Notice",
                     System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Warning);
                 return;
             }
             try
             {
                 await Task.Run(() => ExportService.ExportAll(S.BackupFolder!));
-                System.Windows.MessageBox.Show("Eksport zakończony.", "OK",
+                System.Windows.MessageBox.Show("Export completed.", "OK",
                     System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Information);
             }
             catch (System.Exception ex)
             {
                 Logger.Log("Export failed", ex);
-                System.Windows.MessageBox.Show("Błąd eksportu. Szczegóły w logu.",
-                    "Błąd", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
+                System.Windows.MessageBox.Show("Export failed. See log for details.",
+                    "Error", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
             }
         }
 
@@ -63,15 +63,15 @@ namespace MemoDock.ViewModels
             try
             {
                 await Task.Run(() => ExportService.ImportAll(dlg.FileName));
-                ClipboardService.Instance.ForceRefresh(); 
-                System.Windows.MessageBox.Show("Import zakończony.", "OK",
+                ClipboardService.Instance.ForceRefresh();
+                System.Windows.MessageBox.Show("Import completed.", "OK",
                     System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Information);
             }
             catch (System.Exception ex)
             {
                 Logger.Log("Import failed", ex);
-                System.Windows.MessageBox.Show("Błąd importu. Szczegóły w logu.",
-                    "Błąd", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
+                System.Windows.MessageBox.Show("Import failed. See log for details.",
+                    "Error", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
             }
         }
     }


### PR DESCRIPTION
- Add GlobalHotkeyService (RegisterHotKey + MOD_NOREPEAT) using a message-only HwndSource
- Toggle behavior: if window is hidden/minimized → show & focus; if visible → hide (to tray)
- Wire up on startup; dispose on exit
- Remove configurable hotkey from Settings (keep a fixed shortcut for simplicity)
- All user-facing strings remain English (consistent with v1.1 direction)