### PR TITLE
Pinned window (reorder) + UI polish

### DIFF
--- a/src/MemoDock.App/App.xaml
+++ b/src/MemoDock.App/App.xaml
@@ -43,7 +43,28 @@
                 <Setter Property="BorderBrush" Value="{StaticResource BorderBrush1}"/>
                 <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="Padding" Value="10,8"/>
-                <Setter Property="Margin" Value="6,0,6,0"/>
+                <Setter Property="Margin" Value="8,0,8,0"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="TextBox">
+                            <Border x:Name="bd" Background="{TemplateBinding Background}"
+                      BorderBrush="{TemplateBinding BorderBrush}"
+                      BorderThickness="{TemplateBinding BorderThickness}"
+                      CornerRadius="10">
+                                <ScrollViewer x:Name="PART_ContentHost" Margin="0"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                    <Setter TargetName="bd" Property="BorderThickness" Value="2"/>
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Opacity" Value="0.6"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
             </Style>
 
             <Style x:Key="Card" TargetType="Border">
@@ -55,9 +76,23 @@
                 <Setter Property="Margin" Value="0,8,0,0"/>
                 <Setter Property="Effect">
                     <Setter.Value>
-                        <DropShadowEffect Color="#1A000000" BlurRadius="6" ShadowDepth="1" Opacity="0.25"/>
+                        <DropShadowEffect Color="#14000000" BlurRadius="6" ShadowDepth="1" Opacity="0.18"/>
                     </Setter.Value>
                 </Setter>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Effect">
+                            <Setter.Value>
+                                <DropShadowEffect Color="#24000000" BlurRadius="10" ShadowDepth="2" Opacity="0.35"/>
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="RenderTransform">
+                            <Setter.Value>
+                                <TranslateTransform Y="-1"/>
+                            </Setter.Value>
+                        </Setter>
+                    </Trigger>
+                </Style.Triggers>
             </Style>
 
             <Style x:Key="PrimaryButton" TargetType="Button">
@@ -71,12 +106,14 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
-                            <Border x:Name="bd" CornerRadius="12" Background="{TemplateBinding Background}">
-                                <Border.RenderTransform>
-                                    <ScaleTransform ScaleX="1" ScaleY="1"/>
-                                </Border.RenderTransform>
-                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                            </Border>
+                            <Grid>
+                                <Border x:Name="bd" CornerRadius="12" Background="{TemplateBinding Background}">
+                                    <Border.RenderTransform>
+                                        <ScaleTransform ScaleX="1" ScaleY="1"/>
+                                    </Border.RenderTransform>
+                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                            </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentHoverBrush}"/>
@@ -88,6 +125,10 @@
                                         </Setter.Value>
                                     </Setter>
                                     <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentPressedBrush}"/>
+                                </Trigger>
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="bd" Property="BorderThickness" Value="2"/>
+                                    <Setter TargetName="bd" Property="BorderBrush" Value="White"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.6"/>
@@ -123,6 +164,10 @@
                                 <Trigger Property="IsPressed" Value="True">
                                     <Setter TargetName="bd" Property="Background" Value="#1A000000"/>
                                 </Trigger>
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                    <Setter TargetName="bd" Property="BorderThickness" Value="2"/>
+                                </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
                     </Setter.Value>
@@ -136,7 +181,7 @@
                 <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="Padding" Value="14,10"/>
                 <Setter Property="MinHeight" Value="38"/>
-                <Setter Property="MinWidth"  Value="84"/>
+                <Setter Property="MinWidth" Value="84"/>
                 <Setter Property="Cursor" Value="Hand"/>
                 <Setter Property="FontSize" Value="13"/>
                 <Setter Property="Template">
@@ -161,6 +206,10 @@
                                             <ScaleTransform ScaleX="0.98" ScaleY="0.98"/>
                                         </Setter.Value>
                                     </Setter>
+                                </Trigger>
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                    <Setter TargetName="bd" Property="BorderThickness" Value="2"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.6"/>
@@ -203,6 +252,10 @@
                                         </Setter.Value>
                                     </Setter>
                                 </Trigger>
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                    <Setter TargetName="bd" Property="BorderThickness" Value="2"/>
+                                </Trigger>
                                 <Trigger Property="IsChecked" Value="True">
                                     <Setter TargetName="bd" Property="Background" Value="#E8F0FF"/>
                                     <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
@@ -233,6 +286,10 @@
                                     <Setter TargetName="bd" Property="Background" Value="#E8F0FF"/>
                                     <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
                                     <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                                </Trigger>
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                    <Setter TargetName="bd" Property="BorderThickness" Value="2"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>

--- a/src/MemoDock.App/Services/PinnedEvents.cs
+++ b/src/MemoDock.App/Services/PinnedEvents.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MemoDock.App.Services
+{
+    public static class PinnedEvents
+    {
+        public static event Action? Changed;
+        public static void Raise() => Changed?.Invoke();
+    }
+}

--- a/src/MemoDock.App/ViewModels/MainViewModel.cs
+++ b/src/MemoDock.App/ViewModels/MainViewModel.cs
@@ -184,6 +184,7 @@ LIMIT 1000;";
             if (item == null) return;
             StorageService.SetPinned(new[] { item.Id }, item.IsPinned);
             _ = RefreshAsync();
+            MemoDock.App.Services.PinnedEvents.Raise();
         }
 
         [RelayCommand]

--- a/src/MemoDock.App/Views/MainWindow.xaml
+++ b/src/MemoDock.App/Views/MainWindow.xaml
@@ -11,10 +11,10 @@
     <DockPanel>
 
         <Border DockPanel.Dock="Top"
-                Background="{StaticResource SurfaceBrush}"
-                Padding="12"
-                BorderBrush="{StaticResource BorderBrush1}"
-                BorderThickness="0,0,0,1">
+            Background="{StaticResource SurfaceBrush}"
+            Padding="12"
+            BorderBrush="{StaticResource BorderBrush1}"
+            BorderThickness="0,0,0,1">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -26,175 +26,206 @@
                 </Grid.ColumnDefinitions>
 
                 <TextBlock Text="MemoDock"
-                           FontSize="20" FontWeight="SemiBold"
-                           VerticalAlignment="Center" Margin="4,0,20,0"/>
+                   FontSize="20" FontWeight="SemiBold"
+                   VerticalAlignment="Center" Margin="4,0,18,0"/>
 
                 <TextBox Grid.Column="1"
-                         Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}"
-                         MinWidth="360"
-                         ToolTip="Search in text"/>
+                 Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}"
+                 MinWidth="360"
+                 ToolTip="Search in text"/>
 
                 <CheckBox Grid.Column="2" Style="{StaticResource Chip}"
-                          Content="Pinned only"
-                          IsChecked="{Binding ShowPinnedOnly}"
-                          Margin="10,0,0,0" VerticalAlignment="Center"/>
+                  Content="Pinned only"
+                  IsChecked="{Binding ShowPinnedOnly}"
+                  Margin="8,0,0,0" VerticalAlignment="Center"/>
 
                 <Button Grid.Column="3" Style="{StaticResource GhostButton}"
-                        Content="Clear unpinned"
-                        Command="{Binding ClearUnpinnedAsyncCommand}"
-                        Margin="12,0,0,0"/>
+                Content="Clear unpinned"
+                Command="{Binding ClearUnpinnedAsyncCommand}"
+                Margin="8,0,0,0"/>
 
                 <Button Grid.Column="4" x:Name="ActionsButton"
-                        Style="{StaticResource GhostButton}"
-                        Content="Actions"
-                        Margin="12,0,0,0"
-                        Click="ActionsButton_Click">
+                Style="{StaticResource GhostButton}"
+                Content="Actions"
+                Margin="8,0,0,0"
+                Click="ActionsButton_Click">
                     <Button.ContextMenu>
                         <ContextMenu Placement="Bottom">
                             <MenuItem Header="Pin selected"
-                                      Command="{Binding PinSelectedCommand}"
-                                      IsEnabled="{Binding HasSelection}"/>
+                        Command="{Binding PinSelectedCommand}"
+                        IsEnabled="{Binding HasSelection}"/>
                             <MenuItem Header="Unpin selected"
-                                      Command="{Binding UnpinSelectedCommand}"
-                                      IsEnabled="{Binding HasSelection}"/>
+                        Command="{Binding UnpinSelectedCommand}"
+                        IsEnabled="{Binding HasSelection}"/>
                             <Separator/>
                             <MenuItem Header="Delete selected"
-                                      Command="{Binding DeleteSelectedCommand}"
-                                      IsEnabled="{Binding HasSelection}"/>
+                        Command="{Binding DeleteSelectedCommand}"
+                        IsEnabled="{Binding HasSelection}"/>
                         </ContextMenu>
                     </Button.ContextMenu>
                 </Button>
 
                 <Button Grid.Column="5" Style="{StaticResource GhostButton}"
-                        Content="Settings"
-                        Click="OpenSettings_Click"
-                        Margin="12,0,0,0"/>
+                Content="Settings"
+                Click="OpenSettings_Click"
+                Margin="8,0,0,0"/>
             </Grid>
         </Border>
 
-        <ListBox x:Name="MainList"
-                 ItemsSource="{Binding View}"
-                 SelectionMode="Extended"
-                 Background="{x:Null}" BorderThickness="0"
-                 ScrollViewer.CanContentScroll="True"
-                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                 VirtualizingPanel.IsVirtualizing="True"
-                 VirtualizingPanel.VirtualizationMode="Recycling"
-                 VirtualizingPanel.ScrollUnit="Pixel"
-                 HorizontalContentAlignment="Stretch"
-                 AllowDrop="True"
-                 PreviewMouseLeftButtonDown="MainList_PreviewMouseLeftButtonDown"
-                 MouseMove="MainList_MouseMove"
-                 DragOver="MainList_DragOver"
-                 Drop="MainList_Drop">
+        <Grid>
+            <ListBox x:Name="MainList"
+               ItemsSource="{Binding View}"
+               SelectionMode="Extended"
+               Background="{x:Null}" BorderThickness="0"
+               ScrollViewer.CanContentScroll="True"
+               ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+               VirtualizingPanel.IsVirtualizing="True"
+               VirtualizingPanel.VirtualizationMode="Recycling"
+               VirtualizingPanel.ScrollUnit="Pixel"
+               HorizontalContentAlignment="Stretch"
+               AllowDrop="True"
+               PreviewMouseLeftButtonDown="MainList_PreviewMouseLeftButtonDown"
+               MouseMove="MainList_MouseMove"
+               DragOver="MainList_DragOver"
+               Drop="MainList_Drop">
 
-            <ListBox.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <VirtualizingStackPanel/>
-                </ItemsPanelTemplate>
-            </ListBox.ItemsPanel>
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel/>
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
 
-            <ListBox.ItemContainerStyle>
-                <Style TargetType="ListBoxItem">
-                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
-                    <Setter Property="Padding" Value="0"/>
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                </Style>
-            </ListBox.ItemContainerStyle>
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem">
+                        <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
+                        <Setter Property="Padding" Value="0"/>
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    </Style>
+                </ListBox.ItemContainerStyle>
 
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <Border Style="{StaticResource Card}">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition/>
-                                <ColumnDefinition Width="20"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Border Style="{StaticResource Card}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition/>
+                                    <ColumnDefinition Width="20"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
 
-                            <Border Background="{StaticResource SurfaceAltBrush}"
-                                    CornerRadius="10" Width="80" Height="80" Margin="0,0,14,0"
-                                    BorderBrush="{StaticResource BorderBrush1}" BorderThickness="1">
-                                <Grid>
-                                    <Image Width="80" Height="80" Stretch="UniformToFill"
-                                           Source="{Binding Thumbnail}">
-                                        <Image.Style>
-                                            <Style TargetType="Image">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Type}" Value="image">
-                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Image.Style>
-                                    </Image>
+                                <Border Background="{StaticResource SurfaceAltBrush}"
+                        CornerRadius="10" Width="80" Height="80" Margin="0,0,14,0"
+                        BorderBrush="{StaticResource BorderBrush1}" BorderThickness="1">
+                                    <Grid>
+                                        <Image Width="80" Height="80" Stretch="UniformToFill"
+                           Source="{Binding Thumbnail}">
+                                            <Image.Style>
+                                                <Style TargetType="Image">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Type}" Value="image">
+                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Image.Style>
+                                        </Image>
 
-                                    <TextBlock Text="TXT" VerticalAlignment="Center"
-                                               HorizontalAlignment="Center" FontWeight="Bold"
-                                               Foreground="{StaticResource TextMutedBrush}">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Type}" Value="text">
-                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                </Grid>
-                            </Border>
-
-                            <StackPanel Grid.Column="1">
-                                <TextBlock Text="{Binding DisplayText}" TextWrapping="Wrap" MaxHeight="64"/>
-                                <TextBlock Text="{Binding UpdatedAt, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
-                                           Foreground="{StaticResource TextMutedBrush}"
-                                           Margin="0,6,0,0"/>
-                            </StackPanel>
-
-                            <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Top">
-                                <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
-                                          VerticalAlignment="Center"
-                                          Margin="0,0,10,0"
-                                          ToolTip="Select"/>
-
-                                <Button Style="{StaticResource ActionButton}" Content="Copy"
-                                        Command="{Binding CopyToClipboardCommand}"
-                                        Margin="0,0,10,0"/>
-
-                                <Button Style="{StaticResource ActionButton}" Content="History"
-                                        Command="{Binding DataContext.OpenTimelineCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                        CommandParameter="{Binding}"
-                                        Margin="0,0,10,0"/>
-
-                                <ToggleButton Style="{StaticResource PinToggle}"
-                                              MinWidth="84" MinHeight="38"
-                                              IsChecked="{Binding IsPinned, Mode=TwoWay}"
-                                              Command="{Binding DataContext.TogglePinCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                              CommandParameter="{Binding}">
-                                    <ToggleButton.Content>
-                                        <TextBlock>
+                                        <TextBlock Text="TXT" VerticalAlignment="Center"
+                               HorizontalAlignment="Center" FontWeight="Bold"
+                               Foreground="{StaticResource TextMutedBrush}">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
-                                                    <Setter Property="Text" Value="Pin"/>
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding IsPinned}" Value="True">
-                                                            <Setter Property="Text" Value="Pinned"/>
+                                                        <DataTrigger Binding="{Binding Type}" Value="text">
+                                                            <Setter Property="Visibility" Value="Visible"/>
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
                                             </TextBlock.Style>
                                         </TextBlock>
-                                    </ToggleButton.Content>
-                                </ToggleButton>
-                            </StackPanel>
-                        </Grid>
-                    </Border>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
+                                    </Grid>
+                                </Border>
+
+                                <StackPanel Grid.Column="1">
+                                    <TextBlock Text="{Binding DisplayText}" TextWrapping="Wrap" MaxHeight="64"/>
+                                    <TextBlock Text="{Binding UpdatedAt, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
+                             Foreground="{StaticResource TextMutedBrush}"
+                             Margin="0,6,0,0"/>
+                                </StackPanel>
+
+                                <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Top">
+                                    <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                            VerticalAlignment="Center"
+                            Margin="0,0,10,0"
+                            ToolTip="Select"/>
+
+                                    <Button Style="{StaticResource ActionButton}" Content="Copy"
+                          Command="{Binding CopyToClipboardCommand}"
+                          Margin="0,0,10,0"/>
+
+                                    <Button Style="{StaticResource ActionButton}" Content="History"
+                          Command="{Binding DataContext.OpenTimelineCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                          CommandParameter="{Binding}"
+                          Margin="0,0,10,0"/>
+
+                                    <ToggleButton Style="{StaticResource PinToggle}"
+                                MinWidth="84" MinHeight="38"
+                                IsChecked="{Binding IsPinned, Mode=TwoWay}"
+                                Command="{Binding DataContext.TogglePinCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                CommandParameter="{Binding}">
+                                        <ToggleButton.Content>
+                                            <TextBlock>
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Text" Value="Pin"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsPinned}" Value="True">
+                                                                <Setter Property="Text" Value="Pinned"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </ToggleButton.Content>
+                                    </ToggleButton>
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <Border Background="Transparent" IsHitTestVisible="False"
+              Visibility="{Binding View.IsEmpty, Converter={StaticResource BoolToVis}}">
+                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <TextBlock Text="Nothing here yet."
+                     FontSize="18" FontWeight="SemiBold"
+                     HorizontalAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Search}" Value="">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Search}">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                        <TextBlock FontSize="18" FontWeight="SemiBold" Text="No items"/>
+                        <TextBlock FontSize="13" Foreground="{StaticResource TextMutedBrush}"
+                       Text="Copy something, or clear filters."/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Grid>
     </DockPanel>
 </Window>

--- a/src/MemoDock.App/Views/PinnedWindow.xaml
+++ b/src/MemoDock.App/Views/PinnedWindow.xaml
@@ -2,54 +2,114 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:MemoDock.ViewModels"
-        Title="Pinned - MemoDock"
-        Height="460" Width="640" WindowStartupLocation="CenterOwner">
-
+        Title="Pinned - MemoDock" Height="500" Width="720"
+        WindowStartupLocation="CenterOwner"
+        Background="{StaticResource BgBrush}">
     <Window.DataContext>
         <vm:PinnedViewModel/>
     </Window.DataContext>
 
-    <!-- Pinned list with drag & drop -->
-    <ListBox x:Name="PinnedList"
-             ItemsSource="{Binding Pinned}"
-             Background="{x:Null}" BorderThickness="0"
-             SelectionMode="Extended"
-             HorizontalContentAlignment="Stretch"
-             AllowDrop="True"
-             PreviewMouseLeftButtonDown="PinnedList_PreviewMouseLeftButtonDown"
-             MouseMove="PinnedList_MouseMove"
-             DragOver="PinnedList_DragOver"
-             Drop="PinnedList_Drop"
-             ScrollViewer.CanContentScroll="True"
-             VirtualizingPanel.IsVirtualizing="True"
-             VirtualizingPanel.VirtualizationMode="Recycling">
-        <ListBox.ItemsPanel>
-            <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-            </ItemsPanelTemplate>
-        </ListBox.ItemsPanel>
+    <DockPanel>
 
-        <ListBox.ItemContainerStyle>
-            <Style TargetType="ListBoxItem">
-                <Setter Property="Padding" Value="0"/>
-                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-            </Style>
-        </ListBox.ItemContainerStyle>
+        <Border DockPanel.Dock="Top"
+                Background="{StaticResource SurfaceBrush}"
+                Padding="10"
+                BorderBrush="{StaticResource BorderBrush1}"
+                BorderThickness="0,0,0,1">
+            <TextBlock Text="Pinned"
+                       FontWeight="SemiBold" FontSize="16"
+                       VerticalAlignment="Center"/>
+        </Border>
 
-        <ListBox.ItemTemplate>
-            <DataTemplate>
-                <Border Style="{StaticResource Card}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding DisplayText}"
-                                   Width="420"
-                                   TextTrimming="CharacterEllipsis"/>
-                        <Button Style="{StaticResource PrimaryButton}"
-                                Content="Copy"
-                                Command="{Binding CopyToClipboardCommand}"
-                                Margin="10,0,0,0"/>
-                    </StackPanel>
-                </Border>
-            </DataTemplate>
-        </ListBox.ItemTemplate>
-    </ListBox>
+        <ListBox x:Name="PinnedList"
+                 ItemsSource="{Binding Pinned}"
+                 Background="{x:Null}" BorderThickness="0"
+                 ScrollViewer.CanContentScroll="True"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 VirtualizingPanel.IsVirtualizing="True"
+                 VirtualizingPanel.VirtualizationMode="Recycling"
+                 HorizontalContentAlignment="Stretch"
+                 AllowDrop="True"
+                 PreviewMouseLeftButtonDown="PinnedList_PreviewMouseLeftButtonDown"
+                 MouseMove="PinnedList_MouseMove"
+                 DragOver="PinnedList_DragOver"
+                 Drop="PinnedList_Drop">
+
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel/>
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="Padding" Value="0"/>
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Border Style="{StaticResource Card}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Border Background="{StaticResource SurfaceAltBrush}"
+                                    CornerRadius="10" Width="80" Height="80" Margin="0,0,14,0"
+                                    BorderBrush="{StaticResource BorderBrush1}" BorderThickness="1">
+                                <Grid>
+                                    <Image Width="80" Height="80" Stretch="UniformToFill"
+                                           Source="{Binding Thumbnail}">
+                                        <Image.Style>
+                                            <Style TargetType="Image">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Type}" Value="image">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Image.Style>
+                                    </Image>
+                                    <TextBlock Text="TXT" VerticalAlignment="Center"
+                                               HorizontalAlignment="Center" FontWeight="Bold"
+                                               Foreground="{StaticResource TextMutedBrush}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Type}" Value="text">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                            </Border>
+
+                            <StackPanel Grid.Column="1">
+                                <TextBlock Text="{Binding DisplayText}"
+                                           TextWrapping="Wrap"
+                                           TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Text="{Binding UpdatedAt, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
+                                           Foreground="{StaticResource TextMutedBrush}"
+                                           Margin="0,6,0,0"/>
+                            </StackPanel>
+
+                            <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Top">
+                                <Button Style="{StaticResource ActionButton}" Content="Copy"
+                                        Command="{Binding CopyToClipboardCommand}"
+                                        Margin="0,0,10,0"/>
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </DockPanel>
 </Window>


### PR DESCRIPTION
Pinned Window
- New Pinned window showing pinned items only.
- Drag & drop reorder; order persisted in DB.
- Live sync with main window (re-pin, unpin, delete reflect immediately).

UI polish
- Consistent spacing on top bar and cards.
- Card hover (subtle lift) and keyboard focus outlines.
- Empty state when there are no items / results.

Notes
- Main window selection + actions remain unchanged.
- No user-facing settings change